### PR TITLE
Add CI pipelines

### DIFF
--- a/.github/workflows/dystopia-game.yml
+++ b/.github/workflows/dystopia-game.yml
@@ -65,10 +65,10 @@ jobs:
         path: |
           dys-protocol/generated/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-benchmark-${{ github.run_id }}
+        key: ${{ runner.os }}-cargo-benchmark-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}
         restore-keys: |
-          ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-benchmark-
-          ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          ${{ runner.os }}-cargo-benchmark-${{ hashFiles('**/Cargo.lock') }}-
+          ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
           ${{ runner.os }}-cargo-
     - name: Run benchmarks
       run: cargo bench

--- a/.github/workflows/dystopia-game.yml
+++ b/.github/workflows/dystopia-game.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: dystopia-game
 
 on:
   push:
@@ -33,8 +33,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install build prereqs
         run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
-      - name: Load read-only cached build
-        uses: actions/cache/restore@v4.2.3
+      - name: Load cached build
+        uses: actions/cache@v4.2.3
         with:
           path: target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -49,11 +49,16 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install build prereqs
       run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
-    - name: Load writeable cached build
-      uses: actions/cache/save@v4.2.3
+    - name: Load cached build
+      uses: actions/cache@v4.2.3
       with:
         path: target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Load latest benchmark artifacts
+      uses: actions/cache@v4.2.3
+      with:
+        path: target/criterion
+        key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
     - name: Run benchmarks
       run: cargo bench
       # ZJ-TODO: alert on major regression?

--- a/.github/workflows/dystopia-game.yml
+++ b/.github/workflows/dystopia-game.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install build prereqs
         run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
       - name: Load cached build
-        uses: actions/cache@v4.2.3
+        uses: actions/cache/restore@v4.2.3
         with:
           path: target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -50,7 +50,7 @@ jobs:
     - name: Install build prereqs
       run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
     - name: Load cached build
-      uses: actions/cache@v4.2.3
+      uses: actions/cache/restore@v4.2.3
       with:
         path: target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/dystopia-game.yml
+++ b/.github/workflows/dystopia-game.yml
@@ -54,12 +54,12 @@ jobs:
       with:
         path: target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Load latest benchmark artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: bench-latest
-        path: target/criterion/
-        merge-multiple: true
+#    - name: Load latest benchmark artifacts
+#      uses: actions/download-artifact@v4
+#      with:
+#        name: bench-latest
+#        path: target/criterion/
+#        merge-multiple: true
     - name: Run benchmarks
       run: cargo bench
     - name: Upload bench artifacts

--- a/.github/workflows/dystopia-game.yml
+++ b/.github/workflows/dystopia-game.yml
@@ -20,7 +20,9 @@ jobs:
     - name: Cache build
       uses: actions/cache@v4.2.3
       with:
-        path: target/
+        path: |
+          dys-protocol/generated/
+          target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --release --verbose
@@ -36,7 +38,9 @@ jobs:
       - name: Load cached build
         uses: actions/cache@v4.2.3
         with:
-          path: target/
+          path: |
+            dys-protocol/generated/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Run tests
         run: cargo test --release --verbose
@@ -52,10 +56,13 @@ jobs:
     - name: Load cached build
       uses: actions/cache@v4.2.3
       with:
-        path: target/
+        path: |
+          dys-protocol/generated/
+          target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-benchmark-${{ github.run_id }}
         restore-keys: |
           ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-benchmark-
+          ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           ${{ runner.os }}-cargo-
     - name: Run benchmarks
       run: cargo bench

--- a/.github/workflows/dystopia-game.yml
+++ b/.github/workflows/dystopia-game.yml
@@ -68,7 +68,7 @@ jobs:
         key: ${{ runner.os }}-cargo-benchmark-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}
         restore-keys: |
           ${{ runner.os }}-cargo-benchmark-${{ hashFiles('**/Cargo.lock') }}-
-          ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+          ${{ runner.os }}-cargo-benchmark-
           ${{ runner.os }}-cargo-
     - name: Run benchmarks
       run: cargo bench

--- a/.github/workflows/dystopia-game.yml
+++ b/.github/workflows/dystopia-game.yml
@@ -54,12 +54,12 @@ jobs:
       with:
         path: target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-#    - name: Load latest benchmark artifacts
-#      uses: actions/download-artifact@v4
-#      with:
-#        name: bench-latest
-#        path: target/criterion/
-#        merge-multiple: true
+    - name: Load latest benchmark artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: bench-latest
+        path: target/criterion/
+        merge-multiple: true
     - name: Run benchmarks
       run: cargo bench
     - name: Upload bench artifacts

--- a/.github/workflows/dystopia-game.yml
+++ b/.github/workflows/dystopia-game.yml
@@ -23,7 +23,10 @@ jobs:
         path: |
           dys-protocol/generated/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+          ${{ runner.os }}-cargo-
     - name: Build
       run: cargo build --release --verbose
 
@@ -41,7 +44,10 @@ jobs:
           path: |
             dys-protocol/generated/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-
       - name: Run tests
         run: cargo test --release --verbose
 

--- a/.github/workflows/dystopia-game.yml
+++ b/.github/workflows/dystopia-game.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Cache build
       uses: actions/cache@v4.2.3
       with:
-        path: target
+        path: target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --release --verbose
@@ -34,9 +34,9 @@ jobs:
       - name: Install build prereqs
         run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
       - name: Load cached build
-        uses: actions/cache/restore@v4.2.3
+        uses: actions/cache@v4.2.3
         with:
-          path: target
+          path: target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Run tests
         run: cargo test --release --verbose
@@ -50,23 +50,14 @@ jobs:
     - name: Install build prereqs
       run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
     - name: Load cached build
-      uses: actions/cache/restore@v4.2.3
+      uses: actions/cache@v4.2.3
       with:
-        path: target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Load latest benchmark artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: bench-latest
-        path: target/criterion/
-        merge-multiple: true
+        path: target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-benchmark-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-benchmark-
+          ${{ runner.os }}-cargo-
     - name: Run benchmarks
       run: cargo bench
-    - name: Upload bench artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: bench-latest
-        path: target/criterion/
-        overwrite: true
       # ZJ-TODO: alert on major regression?
       # ZJ-TODO: post report somewhere to be web accessible

--- a/.github/workflows/dystopia-game.yml
+++ b/.github/workflows/dystopia-game.yml
@@ -55,11 +55,18 @@ jobs:
         path: target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Load latest benchmark artifacts
-      uses: actions/cache@v4.2.3
+      uses: actions/download-artifact@v4
       with:
-        path: target/criterion
-        key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+        name: bench-latest
+        path: target/criterion/
+        merge-multiple: true
     - name: Run benchmarks
       run: cargo bench
+    - name: Upload bench artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: bench-latest
+        path: target/criterion/
+        overwrite: true
       # ZJ-TODO: alert on major regression?
       # ZJ-TODO: post report somewhere to be web accessible

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,21 +24,33 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --release --verbose
-    - name: Run tests
-      run: cargo test --release --verbose
-  bench:
+
+  test:
     runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache artifacts
+        uses: actions/cache@v4.2.3
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run tests
+        run: cargo test --release --verbose
+
+  benchmarks:
+    runs-on: ubuntu-latest
+    needs: build
 
     steps:
     - uses: actions/checkout@v4
-    - name: Install build prereqs
-      run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
     - name: Cache artifacts
       uses: actions/cache@v4.2.3
       with:
         path: target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Build
-      run: cargo build --release --verbose
     - name: Run benchmarks
       run: cargo bench
+      # ZJ-TODO: alert on major regression?
+      # ZJ-TODO: post report somewhere to be web accessible

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install build prereqs
+        run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
       - name: Cache artifacts
         uses: actions/cache@v4.2.3
         with:
@@ -45,6 +47,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install build prereqs
+      run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
     - name: Cache artifacts
       uses: actions/cache@v4.2.3
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,13 +17,18 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install build prereqs
       run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
-    - name: Cache artifacts
-      uses: actions/cache@v4.2.3
+    - name: Load cached build
+      uses: actions/cache/restore@v4.2.3
       with:
         path: target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --release --verbose
+    - name: Cache build
+      uses: actions/cache/save@v4.2.3
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
   test:
     runs-on: ubuntu-latest
@@ -33,8 +38,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install build prereqs
         run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
-      - name: Cache artifacts
-        uses: actions/cache@v4.2.3
+      - name: Load cached build
+        uses: actions/cache/restore@v4.2.3
         with:
           path: target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -49,8 +54,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install build prereqs
       run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
-    - name: Cache artifacts
-      uses: actions/cache@v4.2.3
+    - name: Load cached build
+      uses: actions/cache/restore@v4.2.3
       with:
         path: target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -58,3 +63,8 @@ jobs:
       run: cargo bench
       # ZJ-TODO: alert on major regression?
       # ZJ-TODO: post report somewhere to be web accessible
+    - name: Save artifacts
+      uses: actions/cache/save@v4.2.3
+      with:
+        path: target/criterion
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,18 +17,13 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install build prereqs
       run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
-    - name: Load cached build
-      uses: actions/cache/restore@v4.2.3
+    - name: Load writeable cached build
+      uses: actions/cache/save@v4.2.3
       with:
         path: target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --release --verbose
-    - name: Cache build
-      uses: actions/cache/save@v4.2.3
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
   test:
     runs-on: ubuntu-latest
@@ -38,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install build prereqs
         run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
-      - name: Load cached build
+      - name: Load read-only cached build
         uses: actions/cache/restore@v4.2.3
         with:
           path: target
@@ -54,8 +49,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install build prereqs
       run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
-    - name: Load cached build
-      uses: actions/cache/restore@v4.2.3
+    - name: Load writeable cached build
+      uses: actions/cache/save@v4.2.3
       with:
         path: target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -63,8 +58,3 @@ jobs:
       run: cargo bench
       # ZJ-TODO: alert on major regression?
       # ZJ-TODO: post report somewhere to be web accessible
-    - name: Save artifacts
-      uses: actions/cache/save@v4.2.3
-      with:
-        path: target/criterion
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,17 +16,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install build prereqs
-      run: sudo apt-get install -yqq alsa
+      run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
     - name: Cache artifacts
       uses: actions/cache@v4.2.3
       with:
-        # A list of files, directories, and wildcard patterns to cache and restore
-        path: |
-          target
-          ~/.cargo/registry
-          ~/.cargo/git
-        # An explicit key for restoring and saving the cache
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}          
+        path: target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --release --verbose
     - name: Run tests
@@ -36,15 +31,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install build prereqs
+      run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
     - name: Cache artifacts
       uses: actions/cache@v4.2.3
       with:
-        # A list of files, directories, and wildcard patterns to cache and restore
-        path: |
-          target
-          ~/.cargo/registry
-          ~/.cargo/git
-        # An explicit key for restoring and saving the cache
+        path: target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build
+      run: cargo build --release --verbose
     - name: Run benchmarks
       run: cargo bench

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install build prereqs
+      run: sudo apt-get install -yqq alsa
     - name: Cache artifacts
       uses: actions/cache@v4.2.3
       with:
@@ -34,15 +36,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Download previous run results
-      uses: actions/download-artifact@v4.3.0
+    - name: Cache artifacts
+      uses: actions/cache@v4.2.3
       with:
-        name: bench-${{ github.ref_name }}-latest
-        path: target/criterion
+        # A list of files, directories, and wildcard patterns to cache and restore
+        path: |
+          target
+          ~/.cargo/registry
+          ~/.cargo/git
+        # An explicit key for restoring and saving the cache
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Run benchmarks
       run: cargo bench
-    - name: Upload run results
-      uses: actions/upload-artifact@v4.6.2
-      with:
-        name: bench-${{ github.ref_name }}-latest
-        path: target/criterion

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,8 +17,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install build prereqs
       run: sudo apt-get install -yqq pkg-config libx11-dev libasound2-dev libudev-dev protobuf-compiler
-    - name: Load writeable cached build
-      uses: actions/cache/save@v4.2.3
+    - name: Cache build
+      uses: actions/cache@v4.2.3
       with:
         path: target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/dys-matchvisualizer/src/main.rs
+++ b/dys-matchvisualizer/src/main.rs
@@ -190,9 +190,18 @@ pub fn initialize_with_canvas(
 fn restart_with_local_game_log() {
     #[cfg(not(target_family = "wasm"))]
     {
-        let game_log_bytes = include_bytes!("../data/game_log.bin");
-        let world_state_bytes = include_bytes!("../data/world_state.bin");
-        load_game_log(game_log_bytes.to_vec(), world_state_bytes.to_vec());
+        let game_log_bytes =
+            std::fs::read(concat!(env!("CARGO_MANIFEST_DIR"), "/data/game_log.bin"))
+                .unwrap();
+
+        let world_state_bytes =
+            std::fs::read(concat!(env!("CARGO_MANIFEST_DIR"), "/data/world_state.bin"))
+                .unwrap();
+
+        load_game_log(
+            game_log_bytes,
+            world_state_bytes
+        );
     }
 }
 

--- a/dys-simulation/benches/simulation.rs
+++ b/dys-simulation/benches/simulation.rs
@@ -5,6 +5,11 @@ use dys_simulation::game::Game;
 use dys_world::{schedule::{calendar::{Date, Month}}, matches::instance::MatchInstance, generator::Generator};
 
 fn game_simulation_benchmark(c: &mut Criterion) {
+    // These tests take a while, so use a smaller sample size
+    // Default is 100
+    let mut group = c.benchmark_group("simulation");
+    group.sample_size(20);
+
     let world = Generator::new().generate_world(&mut StdRng::from_os_rng());
     let game = Game {
         match_instance: MatchInstance {
@@ -18,7 +23,8 @@ fn game_simulation_benchmark(c: &mut Criterion) {
     };
     let seed = &[0; 32];
     
-    c.bench_function("full_game_simulation", |b| b.iter(|| game.simulate_seeded(seed)));
+    group.bench_function("full_game_simulation", |b| b.iter(|| game.simulate_seeded(seed)));
+    group.finish();
 }
 
 criterion_group!(benches, game_simulation_benchmark);


### PR DESCRIPTION
Adds CI pipelines that build, test, and benchmark the project. Clippy should also be added, but requires investigation into the two outstanding warnings that persist (unnecessary `Arc<Mutex<GameState>>` (the simulation is singlethreaded bc of rapier3d enhanced determinism) and complex types), and addressing those in a separate PR feels sane.

Additionally, I'd love to have the criterion benchmarks be accessible via web so we can visualize performance changes over time, but relying on (free) cloud hosted runners for performance metrics doesn't seem smart.